### PR TITLE
Fix crash when calling PeerConnection::close on tvOS.

### DIFF
--- a/ios/Classes/FlutterWebRTCPlugin.m
+++ b/ios/Classes/FlutterWebRTCPlugin.m
@@ -332,9 +332,10 @@
         [self.peerConnections removeObjectForKey:peerConnectionId];
         
         // Clean up peerConnection's streams and tracks
+#if !TARGET_OS_TV
         [peerConnection.remoteStreams removeAllObjects];
         [peerConnection.remoteTracks removeAllObjects];
-        
+#endif
         // Clean up peerConnection's dataChannels.
         NSMutableDictionary<NSNumber *, RTCDataChannel *> *dataChannels
         = peerConnection.dataChannels;


### PR DESCRIPTION
The remoteStreams and remoteTracks appear to be macro'd out of compilation on
tvOS, so trying to call these functions causes runtime error.